### PR TITLE
feat: warn user on inconsistent dtypes

### DIFF
--- a/mostlyai/qa/reporting.py
+++ b/mostlyai/qa/reporting.py
@@ -200,17 +200,6 @@ def report(
         else:
             setup = "1:1"
 
-        _LOG.info("prepare synthetic data for accuracy started")
-        syn = pull_data_for_accuracy(
-            df_tgt=syn_tgt_data,
-            df_ctx=syn_ctx_data,
-            ctx_primary_key=ctx_primary_key,
-            tgt_context_key=tgt_context_key,
-            max_sample_size=max_sample_size_accuracy,
-            setup=setup,
-        )
-        progress.update(completed=5, total=100)
-
         _LOG.info("prepare training data for accuracy started")
         trn = pull_data_for_accuracy(
             df_tgt=trn_tgt_data,
@@ -219,6 +208,18 @@ def report(
             tgt_context_key=tgt_context_key,
             max_sample_size=max_sample_size_accuracy,
             setup=setup,
+        )
+        progress.update(completed=5, total=100)
+
+        _LOG.info("prepare synthetic data for accuracy started")
+        syn = pull_data_for_accuracy(
+            df_tgt=syn_tgt_data,
+            df_ctx=syn_ctx_data,
+            ctx_primary_key=ctx_primary_key,
+            tgt_context_key=tgt_context_key,
+            max_sample_size=max_sample_size_accuracy,
+            setup=setup,
+            trn_dtypes=trn.dtypes.to_dict(),
         )
         progress.update(completed=10, total=100)
 

--- a/tests/end_to_end/test_report.py
+++ b/tests/end_to_end/test_report.py
@@ -307,11 +307,13 @@ def test_mixed_dtypes(tmp_path):
             trn_tgt_data=trn_df,
             report_path=tmp_path / "report.html",
         )
-        assert any(
+        expected_warning = (
             "The column(s) ['dt'] have inconsistent data types across `syn`, `trn`, and `hol`. "
             "To achieve the most accurate results, please harmonize the data types of these inputs. "
-            "Proceeding with a best-effort attempt..." in str(warning.message)
-            for warning in w
-        ), "Expected a warning about dtype mismatch for column 'dt'"
+            "Proceeding with a best-effort attempt..."
+        )
+        assert any(expected_warning in str(warning.message) for warning in w), (
+            "Expected a warning about dtype mismatch for column 'dt'"
+        )
     assert statistics.accuracy.overall > 0.6
     assert 0.4 < statistics.similarity.discriminator_auc_training_synthetic < 0.6


### PR DESCRIPTION
This PR tackles [this issue](https://github.com/mostly-ai/mostlyai-qa/issues/102).

The initial observation was that accuracy metrics were lowered, if a column has inconsistent dtype across `syn`, `trn` and `hol` inputs.

Instead of implementing a mechanism that attempts to harmonize dtypes, the approach that was taken is to warn the user of inconsistencies in the input dtypes and let the user fix the them. Trying to accomplish that harmony for the user is tricky and stems from the inherent ambiguity of casting one type to another (e.g. `datetime` to `string`).

One more addition in this PR - for accuracy metrics, the coercing of `syn` to `trn` dtypes is now done as part of `pull_data_for_accuracy` BEFORE sampling text token. This way, the `syn` columns that are of non-string type are treated the same way as `trn` text-like columns.