### PR TITLE
docs: bump minor version of torch and torchvision in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ pip install -U mostlyai-qa
 On Linux, one can explicitly install the CPU-only variant of torch together with `mostlyai-qa`:
 
 ```bash
-pip install -U torch==2.6.0+cpu torchvision==0.21.0+cpu mostlyai-qa --extra-index-url https://download.pytorch.org/whl/cpu
+pip install -U torch==2.7.0+cpu torchvision==0.22.0+cpu mostlyai-qa --extra-index-url https://download.pytorch.org/whl/cpu
 ```
 
 ## Quick Start


### PR DESCRIPTION
Bump torch to 2.7.0 and torchvision to 0.22.0 in README.md.

Torchvision was updated to maintain compatibility with the new torch version (2.7.0), as per the PyTorch version compatibility matrix.