### PR TITLE
chore: update copyright year to 2025 in source and test files; comment out `--use-current-year` from pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
       name: Generate temporary license header file
       entry: |
         bash -c '
-        HEADER_CONTENT="Copyright 2024 MOSTLY AI\n\
+        HEADER_CONTENT="Copyright 2025 MOSTLY AI\n\
         \n\
         Licensed under the Apache License, Version 2.0 (the \"License\");\n\
         you may not use this file except in compliance with the License.\n\
@@ -33,7 +33,7 @@ repos:
         # - --remove-header
         - --license-filepath
         - LICENSE_HEADER
-        - --use-current-year
+        # - --use-current-year
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v5.0.0
   hooks:

--- a/mostlyai/qa/__init__.py
+++ b/mostlyai/qa/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 MOSTLY AI
+# Copyright 2025 MOSTLY AI
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/mostlyai/qa/_accuracy.py
+++ b/mostlyai/qa/_accuracy.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 MOSTLY AI
+# Copyright 2025 MOSTLY AI
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/mostlyai/qa/_common.py
+++ b/mostlyai/qa/_common.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 MOSTLY AI
+# Copyright 2025 MOSTLY AI
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/mostlyai/qa/_distances.py
+++ b/mostlyai/qa/_distances.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 MOSTLY AI
+# Copyright 2025 MOSTLY AI
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/mostlyai/qa/_filesystem.py
+++ b/mostlyai/qa/_filesystem.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 MOSTLY AI
+# Copyright 2025 MOSTLY AI
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/mostlyai/qa/_html_report.py
+++ b/mostlyai/qa/_html_report.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 MOSTLY AI
+# Copyright 2025 MOSTLY AI
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/mostlyai/qa/_sampling.py
+++ b/mostlyai/qa/_sampling.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 MOSTLY AI
+# Copyright 2025 MOSTLY AI
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,19 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#  Copyright 2024 MOSTLY AI Solutions MP GmbH
-#
-#  Licensed under the Apache License, Version 2.0 (the "License");
-#  you may not use this file except in compliance with the License.
-#  You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-#  Unless required by applicable law or agreed to in writing, software
-#  distributed under the License is distributed on an "AS IS" BASIS,
-#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#  See the License for the specific language governing permissions and
-#  limitations under the License.
 import logging
 import random
 import warnings

--- a/mostlyai/qa/_similarity.py
+++ b/mostlyai/qa/_similarity.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 MOSTLY AI
+# Copyright 2025 MOSTLY AI
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/mostlyai/qa/metrics.py
+++ b/mostlyai/qa/metrics.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 MOSTLY AI
+# Copyright 2025 MOSTLY AI
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/mostlyai/qa/reporting.py
+++ b/mostlyai/qa/reporting.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 MOSTLY AI
+# Copyright 2025 MOSTLY AI
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/mostlyai/qa/reporting_from_statistics.py
+++ b/mostlyai/qa/reporting_from_statistics.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 MOSTLY AI
+# Copyright 2025 MOSTLY AI
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 MOSTLY AI
+# Copyright 2025 MOSTLY AI
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/end_to_end/__init__.py
+++ b/tests/end_to_end/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 MOSTLY AI
+# Copyright 2025 MOSTLY AI
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/end_to_end/test_report.py
+++ b/tests/end_to_end/test_report.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 MOSTLY AI
+# Copyright 2025 MOSTLY AI
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 MOSTLY AI
+# Copyright 2025 MOSTLY AI
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 MOSTLY AI
+# Copyright 2025 MOSTLY AI
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/test_accuracy.py
+++ b/tests/unit/test_accuracy.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 MOSTLY AI
+# Copyright 2025 MOSTLY AI
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 MOSTLY AI
+# Copyright 2025 MOSTLY AI
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/test_filesystem.py
+++ b/tests/unit/test_filesystem.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 MOSTLY AI
+# Copyright 2025 MOSTLY AI
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/test_html_report.py
+++ b/tests/unit/test_html_report.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 MOSTLY AI
+# Copyright 2025 MOSTLY AI
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/test_similarity.py
+++ b/tests/unit/test_similarity.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 MOSTLY AI
+# Copyright 2025 MOSTLY AI
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Aligns licensing metadata to 2025 and tweaks pre-commit license insertion.
> 
> - Updates `Copyright` headers in `mostlyai/qa/*.py` and `tests/**` to 2025
> - In `.pre-commit-config.yaml`, sets generated `LICENSE_HEADER` year to 2025 and comments out `--use-current-year` for `insert-license`
> 
> No functional code changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b8637c6af0c9751e219eebf34b4e6636af5740f7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->